### PR TITLE
node v4.6.0 で無理やり動かすパッチ

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,7 @@
  * @ndaidong
 **/
 
+'use strict';
+
 exports = module.exports = require('./src/paypal-nvp-api');
 exports.version = require('./package').version;

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "version": "1.2.25",
   "name": "paypal-nvp-api",
-  "description": "Node.js wrapper for the Paypal Name-Value Pair — NVP ",
+  "description": "Node.js wrapper for the Paypal Name-Value Pair — NVP, Monky patch for node v4.6.0",
   "homepage": "https://www.npmjs.com/package/paypal-nvp-api",
   "repository": {
     "type": "git",
-    "url": "git@github.com:ndaidong/paypal-nvp-api.git"
+    "url": "git@github.com:tokyootakumode/paypal-nvp-api.git"
   },
-  "author": "@ndaidong",
+  "author": "@nidate",
   "main": "./index.js",
   "engines": {
-    "node": ">= 6.0"
+    "node": ">= 4.6.0"
   },
   "scripts": {
     "lint": "eslint ./src ./test",
@@ -23,8 +23,8 @@
     "coveralls": "npm test && cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "bellajs": "6.*.*",
-    "promise-wtf": "1.*.*",
+    "bellajs": "5.1.3",
+    "bluebird": "^3.4.6",
     "request": "2.*.*"
   },
   "devDependencies": {

--- a/src/paypal-nvp-api.js
+++ b/src/paypal-nvp-api.js
@@ -4,8 +4,10 @@
  * Refer: https://developer.paypal.com/docs/classic/api/
  **/
 
+'use strict';
+
 var bella = require('bellajs');
-var Promise = require('promise-wtf');
+var Promise = require('bluebird');
 var request = require('request');
 
 var version = 204;


### PR DESCRIPTION
node 4.6.0で

```
/Users/kunix/Documents/00work/tom/src/node_modules/paypal-nvp-api/src/paypal-nvp-api.js:16
  let s = '';
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

となる問題のとりあえずの対処。

bella.jsのバージョンを落として、promiseのライブラリをbluebirdにした。

